### PR TITLE
Add signature struct

### DIFF
--- a/libcylinder/src/error.rs
+++ b/libcylinder/src/error.rs
@@ -58,3 +58,15 @@ impl std::fmt::Display for SignatureVerificationError {
         }
     }
 }
+
+/// An error that can occur when parsing a signature
+#[derive(Debug)]
+pub struct SignatureParseError(pub String);
+
+impl Error for SignatureParseError {}
+
+impl std::fmt::Display for SignatureParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -19,10 +19,12 @@
 mod error;
 mod hex;
 mod key;
+mod signature;
 pub mod signing;
 
-pub use error::{SignatureVerificationError, SigningError};
+pub use error::{SignatureParseError, SignatureVerificationError, SigningError};
 pub use key::{KeyParseError, PrivateKey, PublicKey};
+pub use signature::Signature;
 
 /// A signer for arbitrary messages
 pub trait Signer: Send {

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -29,7 +29,7 @@ pub use signature::Signature;
 /// A signer for arbitrary messages
 pub trait Signer: Send {
     /// Signs the given message
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, SigningError>;
+    fn sign(&self, message: &[u8]) -> Result<Signature, SigningError>;
 
     /// Returns the signer's public key
     fn public_key(&self) -> Result<PublicKey, SigningError>;
@@ -41,7 +41,7 @@ pub trait SignatureVerifier: Send {
     fn verify(
         &self,
         message: &[u8],
-        signature: &[u8],
+        signature: &Signature,
         public_key: &PublicKey,
     ) -> Result<bool, SignatureVerificationError>;
 }

--- a/libcylinder/src/signature.rs
+++ b/libcylinder/src/signature.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Intel Corporation
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use crate::error::SignatureParseError;
+use crate::hex;
+
+/// A general signature value.
+///
+/// This signature type may wrap any signature that can be represented as bytes.
+#[derive(PartialEq, Eq)]
+pub struct Signature(Vec<u8>);
+
+impl Signature {
+    /// Constructs a new Signature from a given set of bytes.
+    pub fn new(sig_bytes: Vec<u8>) -> Self {
+        Self(sig_bytes)
+    }
+
+    /// Creates a new Signature from a hex string.
+    ///
+    /// # Errors
+    ///
+    /// Returns a SignatureParseError if the provided signature string is not valid hex.
+    pub fn from_hex(sig_hex: &str) -> Result<Self, SignatureParseError> {
+        hex::hex_str_to_bytes(sig_hex)
+            .map(Self)
+            .map_err(|e| SignatureParseError(e.to_string()))
+    }
+
+    /// Takes the bytes out of this Signature.
+    pub fn take_bytes(self) -> Vec<u8> {
+        self.0
+    }
+
+    /// Returns a slice of the internal bytes.
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns a new hex representation of this Signature.
+    pub fn as_hex(&self) -> String {
+        hex::bytes_to_hex_str(&self.0)
+    }
+}
+
+impl std::fmt::Debug for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_tuple("Signature").field(&self.as_hex()).finish()
+    }
+}
+
+impl std::fmt::Display for Signature {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str(&self.as_hex())
+    }
+}


### PR DESCRIPTION
This change adds a Signature struct in order to provide a strong type guarantee to the API. It provides methods to create a signature from bytes or hex string - both with a parse error and unchecked.

In the trait API, it removes the inconsistency between `Context::verify` and `SignatureVerifier::verify` where one took a string and the other bytes.