### PR TITLE
Move pem from default to stable features

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -26,10 +26,11 @@ description = """\
 repository = "https://github.com/cargill/cylinder"
 
 [features]
-default = ["pem"]
+default = []
 
 stable = [
     "default",
+    "pem",
 ]
 
 experimental = [


### PR DESCRIPTION
This change makes the PEM support feature optional.  It reduces the need to fetch and build the openssl dependency.