### PR TITLE
Add hash implementation of signing traits

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -44,10 +44,10 @@ hash = ["sha2"]
 pem = ["openssl"]
 
 [dependencies]
-secp256k1 = "0.17"
+openssl = { version = "0.10", optional = true }
 rand = "0.7"
 rust-crypto = "0.2"
-openssl = { version = "0.10", optional = true }
+secp256k1 = "0.17"
 sha2 = { version = "0.9", optional = true }
 
 [package.metadata.docs.rs]

--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -36,8 +36,10 @@ experimental = [
   # The experimental feature extends stable:
   "stable",
   # The following features are experimental:
+  "hash",
 ]
 
+hash = ["sha2"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
 
@@ -46,6 +48,7 @@ secp256k1 = "0.17"
 rand = "0.7"
 rust-crypto = "0.2"
 openssl = { version = "0.10", optional = true }
+sha2 = { version = "0.9", optional = true }
 
 [package.metadata.docs.rs]
 features = [

--- a/libcylinder/src/hash.rs
+++ b/libcylinder/src/hash.rs
@@ -1,0 +1,76 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Signer/verifier implemenation for hashes instead of real signatures
+//!
+//! This implementation is intended for testing purposes only.
+
+use sha2::{Digest, Sha512};
+
+use super::{
+    Context, ContextError, PrivateKey, PublicKey, Signature, Signer, SigningError,
+    VerificationError, Verifier,
+};
+
+pub struct HashContext;
+
+impl Context for HashContext {
+    fn new_signer(&self, _key: PrivateKey) -> Box<dyn Signer> {
+        Box::new(HashSigner)
+    }
+
+    fn new_verifier(&self) -> Box<dyn Verifier> {
+        Box::new(HashVerifier)
+    }
+
+    fn new_random_private_key(&self) -> PrivateKey {
+        PrivateKey::new(vec![])
+    }
+
+    fn get_public_key(&self, _private_key: &PrivateKey) -> Result<PublicKey, ContextError> {
+        Ok(PublicKey::new(vec![]))
+    }
+}
+
+/// Generates hashes from messages
+#[derive(Clone)]
+pub struct HashSigner;
+
+impl Signer for HashSigner {
+    fn sign(&self, message: &[u8]) -> Result<Signature, SigningError> {
+        Ok(Signature::new(Sha512::digest(message).to_vec()))
+    }
+
+    fn public_key(&self) -> Result<PublicKey, SigningError> {
+        Ok(PublicKey::new(b"hash_signer".to_vec()))
+    }
+
+    fn clone_box(&self) -> Box<dyn Signer> {
+        Box::new(self.clone())
+    }
+}
+
+/// Verifies message hashes
+pub struct HashVerifier;
+
+impl Verifier for HashVerifier {
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &Signature,
+        _public_key: &PublicKey,
+    ) -> Result<bool, VerificationError> {
+        Ok(signature.as_slice() == Sha512::digest(message).as_slice())
+    }
+}

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -17,6 +17,9 @@
  */
 
 mod error;
+#[cfg(feature = "hash")]
+#[cfg_attr(docsrs, doc(cfg(feature = "hash")))]
+pub mod hash;
 mod hex;
 mod key;
 pub mod secp256k1;


### PR DESCRIPTION
Adds the `HashContext`, `HashSigner`, and `HashVerifier` behind the
`hash` trait. This implementation is intended for testing purposes.

Signed-off-by: Logan Seeley <seeley@bitwise.io>