### PR TITLE
Return only valid random secp256k1 keys

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -48,7 +48,7 @@ pem = ["openssl"]
 openssl = { version = "0.10", optional = true }
 rand = "0.7"
 rust-crypto = "0.2"
-secp256k1 = "0.17"
+secp256k1 = "0.19"
 sha2 = { version = "0.9", optional = true }
 
 [package.metadata.docs.rs]

--- a/libcylinder/src/secp256k1/mod.rs
+++ b/libcylinder/src/secp256k1/mod.rs
@@ -59,9 +59,13 @@ impl Context for Secp256k1Context {
     }
 
     fn new_random_private_key(&self) -> PrivateKey {
-        let mut key = [0u8; secp256k1::constants::SECRET_KEY_SIZE];
-        OsRng.fill_bytes(&mut key);
-        PrivateKey::new(Vec::from(&key[..]))
+        loop {
+            let mut key = [0u8; secp256k1::constants::SECRET_KEY_SIZE];
+            OsRng.fill_bytes(&mut key);
+            if secp256k1::SecretKey::from_slice(&key[..]).is_ok() {
+                break PrivateKey::new(Vec::from(&key[..]));
+            }
+        }
     }
 
     fn get_public_key(&self, private_key: &PrivateKey) -> Result<PublicKey, ContextError> {


### PR DESCRIPTION
Randomly filling an 32 byte array can result in keys that are outside of the curve for secp256k1.  This change ensures that only valid keys are returned from new_random_private_key.

Additionally: 

Updates secp256k1 dependency from 0.17 -> 0.19