### PR TITLE
Cylinder jwt

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -38,9 +38,11 @@ experimental = [
   "stable",
   # The following features are experimental:
   "hash",
+  "jwt",
 ]
 
 hash = ["sha2"]
+jwt = []
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
 

--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -42,11 +42,13 @@ experimental = [
 ]
 
 hash = ["sha2"]
-jwt = []
+jwt = ["json", "base64"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
 
 [dependencies]
+base64 = { version = "0.13", optional = true }
+json = { version = "0.12", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.7"
 rust-crypto = "0.2"

--- a/libcylinder/src/jwt/error.rs
+++ b/libcylinder/src/jwt/error.rs
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+use std::error::Error;
+use std::fmt;
+
+/// An error that may occur while building the token.
+#[derive(Debug)]
+pub struct JsonWebTokenBuildError {
+    message: String,
+    source: Box<dyn Error>,
+}
+
+impl JsonWebTokenBuildError {
+    /// Construct a new error.
+    pub fn new<E: Into<Box<dyn Error>>>(message: String, source: E) -> Self {
+        Self {
+            message,
+            source: source.into(),
+        }
+    }
+}
+
+impl fmt::Display for JsonWebTokenBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl Error for JsonWebTokenBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&*self.source)
+    }
+}
+
+/// A JWT string could not be parsed or validated.
+#[derive(Debug)]
+pub enum JsonWebTokenParseError {
+    InvalidToken(String),
+    InvalidSignature,
+}
+
+impl fmt::Display for JsonWebTokenParseError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            JsonWebTokenParseError::InvalidToken(msg) => f.write_str(&msg),
+            JsonWebTokenParseError::InvalidSignature => f.write_str("The signature was invalid"),
+        }
+    }
+}
+
+impl Error for JsonWebTokenParseError {}

--- a/libcylinder/src/jwt/mod.rs
+++ b/libcylinder/src/jwt/mod.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2018-2020 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */

--- a/libcylinder/src/jwt/mod.rs
+++ b/libcylinder/src/jwt/mod.rs
@@ -14,3 +14,510 @@
  * limitations under the License.
  * ------------------------------------------------------------------------------
  */
+
+//! Provides a set of APIs to both generate JSON Web Tokens with cylinder signing algorithms, as
+//! well as parse and cryptographically validate the contents of the strings.
+
+mod error;
+
+use std::collections::HashMap;
+
+use crate::{PublicKey, Signature, Signer, Verifier};
+
+pub use error::{JsonWebTokenBuildError, JsonWebTokenParseError};
+
+/// Builder for constructing the JWT string that would be included in HTTP request headers.
+#[derive(Default)]
+pub struct JsonWebTokenBuilder {
+    header: HashMap<String, String>,
+    claims: HashMap<String, String>,
+}
+
+impl JsonWebTokenBuilder {
+    /// Construct a new instance of the builder.
+    pub fn new() -> Self {
+        Self {
+            header: HashMap::with_capacity(0),
+            claims: HashMap::with_capacity(0),
+        }
+    }
+
+    /// Set the header of the token.
+    ///
+    /// The standard header keys of "alg" and "typ" will be added to the resulting JSON object. If
+    /// these keys are included in the given map, they will be overridden at build time.
+    pub fn with_header(mut self, header: HashMap<String, String>) -> Self {
+        self.header = header;
+
+        self
+    }
+
+    /// Set the claims of the token.
+    ///
+    /// Th standard header of "iss" (issuer) will be added to the resulting JSON object. This will
+    /// be set to the public key value of the signer used at build time. If the key is included in
+    /// the given map, it will be overridden.
+    pub fn with_claims(mut self, claims: HashMap<String, String>) -> Self {
+        self.claims = claims;
+
+        self
+    }
+
+    /// Serialize and signs the JsonWebToken.
+    ///
+    /// ```
+    /// # use std::collections::HashMap;
+    /// # use cylinder::{jwt::JsonWebTokenBuilder, PrivateKey, Context, Signer, secp256k1::Secp256k1Context};
+    /// # let context = Secp256k1Context::new();
+    /// # let private_key = PrivateKey::new(vec![
+    /// #     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    /// #     0, 0, 1,
+    /// # ]);
+    /// # let signer = context.new_signer(private_key);
+    ///
+    /// let mut header = HashMap::new();
+    /// header.insert("example".into(), "header".into());
+    ///
+    /// let mut claims = HashMap::new();
+    /// claims.insert("example".into(), "claim".into());
+    ///
+    /// let encoded_token = JsonWebTokenBuilder::new()
+    ///     .with_header(header)
+    ///     .with_claims(claims)
+    ///     .build(&*signer)
+    ///     .expect("Unable to generate auth JWT");
+    /// ```
+    ///
+    /// The resulting string is
+    ///
+    ///  ```
+    ///  "[Base-64-encoded bytes of the UTF-8 string of the header JSON].\
+    ///   [Base-64-encoded bytes of the UTF-8 string of the claims JSON].\
+    ///   [Base-64-encoded signature]"
+    ///   # ;
+    ///   # ()
+    ///  ```
+    ///
+    /// # Errors
+    ///
+    /// A `JsonWebTokenBuildError` may be returned if the token can not be properly built or
+    /// signed.
+    pub fn build(self, signer: &dyn Signer) -> Result<String, JsonWebTokenBuildError> {
+        let mut jwt_header = json::JsonValue::new_object();
+
+        for (k, v) in self.header {
+            jwt_header[k] = v.into();
+        }
+        jwt_header["alg"] = "secp256k1".into();
+        jwt_header["typ"] = "cylinder+jwt".into();
+
+        // Header bytes are UTF-8 bytes of the JSON string representation of the header
+        let header_bytes = json::stringify(jwt_header).into_bytes();
+
+        let public_key = signer.public_key().map_err(|e| {
+            JsonWebTokenBuildError::new(
+                "Unable to get the public key from the provided signer".into(),
+                e,
+            )
+        })?;
+
+        let mut claims = json::JsonValue::new_object();
+        for (k, v) in self.claims {
+            claims[k] = v.into()
+        }
+
+        claims["iss"] = public_key.as_hex().into();
+
+        // Claims bytes are the UTF-8 bytes of the JSON string representation of the header
+        let claims_bytes = json::stringify(claims).into_bytes();
+
+        let mut token = String::new();
+
+        token.push_str(&base64::encode(header_bytes));
+        token.push('.');
+        token.push_str(&base64::encode(claims_bytes));
+
+        let signature = signer
+            .sign(token.as_bytes())
+            .map_err(|e| JsonWebTokenBuildError::new("Unable to sign the token".into(), e))?;
+
+        token.push('.');
+        token.push_str(&base64::encode(signature.as_slice()));
+
+        Ok(token)
+    }
+}
+
+/// Parses JsonWebToken struct from an encoded token.  The token's signature is verified before the
+/// parsed value is returned.
+pub struct JsonWebTokenParser<'a> {
+    verifier: &'a dyn Verifier,
+}
+
+impl<'a> JsonWebTokenParser<'a> {
+    /// Construct a new parser instance around the given verifier.
+    pub fn new(verifier: &'a dyn Verifier) -> Self {
+        Self { verifier }
+    }
+
+    /// Parse the token string provided and verify the included signature
+    /// with the parser's Verifier instance.
+    ///
+    /// # Errors
+    ///
+    /// A `JsonWebTokenParseError` may be returned if the token is not properly formed or the
+    /// signature is not valid.
+    pub fn parse(&self, jwt_string: &str) -> Result<JsonWebToken, JsonWebTokenParseError> {
+        let mut encoded_token_parts = jwt_string.split('.');
+        let (encoded_header, encoded_claims, encoded_signature) = {
+            match (
+                encoded_token_parts.next(),
+                encoded_token_parts.next(),
+                encoded_token_parts.next(),
+            ) {
+                (Some(encoded_header), Some(encoded_claims), Some(encoded_signature)) => {
+                    (encoded_header, encoded_claims, encoded_signature)
+                }
+                (Some(_), Some(_), None) => {
+                    return Err(JsonWebTokenParseError::InvalidToken(
+                        "Missing signature".into(),
+                    ))
+                }
+                (Some(_), None, _) => {
+                    return Err(JsonWebTokenParseError::InvalidToken(
+                        "Missing claims".into(),
+                    ))
+                }
+                (None, _, _) => unreachable!(),
+            }
+        };
+
+        let header = Self::parse_object(encoded_header, |object| {
+            if !object.has_key("typ") || object["typ"] != "cylinder+jwt" {
+                return Err(JsonWebTokenParseError::InvalidToken(
+                    "JWT does not support cylinder extensions".into(),
+                ));
+            }
+
+            if !object.has_key("alg") || object["alg"] != "secp256k1" {
+                return Err(JsonWebTokenParseError::InvalidToken(
+                    "JWT does not use a supported algoritm".into(),
+                ));
+            }
+
+            Ok(())
+        })?;
+
+        let claims = Self::parse_object(encoded_claims, |object| {
+            if !object.has_key("iss") {
+                Err(JsonWebTokenParseError::InvalidToken(
+                    "JWT claims has not provided the \"iss\" field".into(),
+                ))
+            } else {
+                Ok(())
+            }
+        })?;
+
+        let signature_bytes = base64::decode(encoded_signature).map_err(|_| {
+            JsonWebTokenParseError::InvalidToken(
+                "JWT signature is not valid Base64 encoded bytes".into(),
+            )
+        })?;
+
+        let public_key = PublicKey::new_from_hex(&claims["iss"]).map_err(|_| {
+            JsonWebTokenParseError::InvalidToken(
+                "JWT claims do not include a valid public key".into(),
+            )
+        })?;
+
+        let verified = self
+            .verifier
+            .verify(
+                format!("{}.{}", encoded_header, encoded_claims).as_bytes(),
+                &Signature::new(signature_bytes),
+                &public_key,
+            )
+            .map_err(|_| JsonWebTokenParseError::InvalidSignature)?;
+
+        if verified {
+            Ok(JsonWebToken {
+                header,
+                claims,
+                issuer: public_key,
+            })
+        } else {
+            Err(JsonWebTokenParseError::InvalidSignature)
+        }
+    }
+
+    fn parse_object<F>(
+        encoded_object: &str,
+        validate: F,
+    ) -> Result<HashMap<String, String>, JsonWebTokenParseError>
+    where
+        F: Fn(&json::JsonValue) -> Result<(), JsonWebTokenParseError>,
+    {
+        let object = base64::decode(encoded_object)
+            .map_err(|_| {
+                JsonWebTokenParseError::InvalidToken(
+                    "JWT object is not valid Base64 encoded bytes".into(),
+                )
+            })
+            .and_then(|object_bytes| {
+                String::from_utf8(object_bytes).map_err(|_| {
+                    JsonWebTokenParseError::InvalidToken(
+                        "JWT object is not valid UTF-8 bytes".into(),
+                    )
+                })
+            })
+            .and_then(|object_str| {
+                json::parse(&object_str).map_err(|_| {
+                    JsonWebTokenParseError::InvalidToken("JWT object is not valid JSON".into())
+                })
+            })?;
+
+        if !object.is_object() {
+            return Err(JsonWebTokenParseError::InvalidToken(
+                "Malformed JWT object: expected object".into(),
+            ));
+        }
+
+        validate(&object)?;
+
+        Ok(object
+            .entries()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect())
+    }
+}
+
+/// JsonWebToken struct used for validation.
+#[derive(Debug)]
+pub struct JsonWebToken {
+    issuer: PublicKey,
+    header: HashMap<String, String>,
+    claims: HashMap<String, String>,
+}
+
+impl JsonWebToken {
+    /// Return the header map for this JsonWebToken
+    pub fn header(&self) -> &HashMap<String, String> {
+        &self.header
+    }
+
+    /// Return the claims map for this JsonWebToken
+    pub fn claims(&self) -> &HashMap<String, String> {
+        &self.claims
+    }
+
+    /// Return the public key of the issuer of this JsonWebToken
+    pub fn issuer(&self) -> &PublicKey {
+        &self.issuer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::{secp256k1::Secp256k1Context, Context, PrivateKey};
+
+    /// This test constructs a signed Json Web Token string and verifies that it can be read and
+    /// verified by the parse method.
+    #[test]
+    fn test_round_trip() {
+        let context = Secp256k1Context::new();
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+        let signer = context.new_signer(private_key);
+
+        let encoded_token = JsonWebTokenBuilder::new()
+            .build(&*signer)
+            .expect("Unable to generate auth JWT");
+
+        let verifier = context.new_verifier();
+
+        let json_web_token = JsonWebTokenParser::new(&*verifier)
+            .parse(&encoded_token)
+            .expect("Unable to get public key from JWT");
+
+        assert_eq!(
+            &signer.public_key().expect("could not get pubkey"),
+            json_web_token.issuer()
+        );
+    }
+
+    /// This test constructs a signed Json Web Token string using custom header values and verifies
+    /// that it can be read and verified by the parse method.
+    #[test]
+    fn test_round_trip_with_custom_header_values() {
+        let context = Secp256k1Context::new();
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+        let signer = context.new_signer(private_key);
+
+        let mut header = HashMap::new();
+        header.insert("test".into(), "hello".into());
+        let encoded_token = JsonWebTokenBuilder::new()
+            .with_header(header)
+            .build(&*signer)
+            .expect("Unable to generate auth JWT");
+
+        let verifier = context.new_verifier();
+
+        let json_web_token = JsonWebTokenParser::new(&*verifier)
+            .parse(&encoded_token)
+            .expect("Unable to get public key from JWT");
+
+        assert_eq!(
+            &signer.public_key().expect("could not get pubkey"),
+            json_web_token.issuer()
+        );
+
+        assert_eq!(
+            Some(&"hello".to_string()),
+            json_web_token.header().get("test")
+        );
+    }
+
+    /// This test constructs a signed JsonWebToken and then replaces the signature with an invalid
+    /// one.  The parse_and_verify method should return an InvalidSignature error variant.
+    #[test]
+    fn test_bad_signature() {
+        let context = Secp256k1Context::new();
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+        let signer = context.new_signer(private_key);
+
+        let encoded_token = JsonWebTokenBuilder::new()
+            .build(&*signer)
+            .expect("Unable to generate auth JWT");
+
+        // Take the first two parts (the header and the claims).
+        let mut token_parts = encoded_token.splitn(3, '.');
+        let header = token_parts.next().expect("no header");
+        let claims = token_parts.next().expect("no claims");
+        let sig = token_parts.next().expect("no signature");
+        let bad_sig = std::iter::repeat('0').take(sig.len()).collect::<String>();
+        let badly_signed_encoded_token = format!("{}.{}.{}", header, claims, bad_sig);
+
+        let verifier = context.new_verifier();
+
+        match JsonWebTokenParser::new(&*verifier).parse(&badly_signed_encoded_token) {
+            Err(JsonWebTokenParseError::InvalidSignature) => (),
+            Err(err) => panic!("Unexpected error {:?}", err),
+            Ok(_) => panic!("Should not have validated the token"),
+        }
+    }
+
+    /// This test constructs a signed JsonWebToken and then replaces the signature with a different
+    /// signer's signature.  The parse_and_verify method should return an InvalidSignature error
+    /// variant.
+    #[test]
+    fn test_alternate_signer() {
+        let context = Secp256k1Context::new();
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+        let signer = context.new_signer(private_key);
+
+        let encoded_token = JsonWebTokenBuilder::new()
+            .build(&*signer)
+            .expect("Unable to generate auth JWT");
+
+        // Take the first two parts (the header and the claims).
+        let mut token_parts = encoded_token.splitn(3, '.');
+        let header = token_parts.next().expect("no header");
+        let claims = token_parts.next().expect("no claims");
+
+        // construct an alternate signer and sign the token
+        let alt_signer = context.new_signer(context.new_random_private_key());
+
+        let bad_sig = alt_signer
+            .sign(format!("{}.{}", header, claims).as_bytes())
+            .expect("Unable to create new signature");
+        let badly_signed_encoded_token = format!("{}.{}.{}", header, claims, bad_sig);
+
+        let verifier = context.new_verifier();
+
+        match JsonWebTokenParser::new(&*verifier).parse(&badly_signed_encoded_token) {
+            Err(JsonWebTokenParseError::InvalidSignature) => (),
+            Err(err) => panic!("Unexpected error {:?}", err),
+            Ok(_) => panic!("Should not have validated the token"),
+        }
+    }
+
+    /// This test create tokens with badly formatted claims and header values, then it confirms
+    /// that the values fail to parse.
+    #[test]
+    fn test_invalid_claims_json_structure() {
+        let context = Secp256k1Context::new();
+        let verifier = context.new_verifier();
+        let parser = JsonWebTokenParser::new(&*verifier);
+
+        // Test badly formatted claims
+        fn test_bad_claims(parser: &JsonWebTokenParser, bad_claims: &str) {
+            let header = r#"{
+              "typ": "cylinder+jwt",
+              "alg": "secp256k1"
+            }"#;
+
+            let token = format!(
+                "{}.{}.changeme",
+                base64::encode(header.as_bytes()),
+                base64::encode(bad_claims.as_bytes())
+            );
+
+            match parser.parse(&token) {
+                Err(JsonWebTokenParseError::InvalidToken(_)) => (),
+                Err(err) => panic!("Unexpected error: {:?}", err),
+                Ok(_) => panic!("Should not have parsed the token"),
+            }
+        }
+
+        // invalid JSON type
+        test_bad_claims(&parser, "[1, 2, 3]");
+        // Missing JSON token
+        test_bad_claims(&parser, r#"{"iss": "foobar""#);
+        // Invalid JSON
+        test_bad_claims(&parser, "bad_json");
+
+        // Test badly formatted claims
+        fn test_bad_header(parser: &JsonWebTokenParser, bad_header: &str) {
+            let claims = r#"{
+              "iss": "somepubkey
+            }"#;
+            let token = format!(
+                "{}.{}.changeme",
+                base64::encode(bad_header.as_bytes()),
+                base64::encode(claims.as_bytes())
+            );
+
+            match parser.parse(&token) {
+                Err(JsonWebTokenParseError::InvalidToken(_)) => (),
+                Err(err) => panic!("Unexpected error: {:?}", err),
+                Ok(_) => panic!("Should not have parsed the token"),
+            }
+        }
+
+        // invalid JSON type
+        test_bad_header(&parser, "[1, 2, 3]");
+        // missing opening token
+        test_bad_header(
+            &parser,
+            r#"
+          "typ": "cylinder+jwt",
+          "alg": "secp256k1"
+        }"#,
+        );
+        // invalid JSON
+        test_bad_header(&parser, "invalid_json");
+    }
+}

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -21,6 +21,9 @@ mod error;
 #[cfg_attr(docsrs, doc(cfg(feature = "hash")))]
 pub mod hash;
 mod hex;
+#[cfg(feature = "jwt")]
+#[cfg_attr(docsrs, doc(cfg(feature = "jwt")))]
+pub mod jwt;
 mod key;
 pub mod secp256k1;
 mod signature;


### PR DESCRIPTION
This PR implements building and parsing of the custom cylinder JSON web token values.

The process is divided between the `JsonWebTokenBuilder`, which is used to construct encoded, signed token.  As of this commit, the header values and claims values are a flat object of (`String`, `String`) pairs.

The token is read and verified by the `JsonWebTokenParser`.  This parser wraps a Verifier instance which provides the signature verification.  It produces `JsonWebToken` struct that can be used to examine the token's claims.

As of this PR, the algorithm choice for the JWT (the field `"alg"` in the header) is hard-coded to `"secp256k1"`, as this is currently the only signing algorithm implemented in Cylinder.