### PR TITLE
Add algorithm name to Context, Signer and Verifier

### DIFF
--- a/libcylinder/src/hash.rs
+++ b/libcylinder/src/hash.rs
@@ -23,9 +23,15 @@ use super::{
     VerificationError, Verifier,
 };
 
+const ALGORITHM_NAME: &str = "sha512";
+
 pub struct HashContext;
 
 impl Context for HashContext {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn new_signer(&self, _key: PrivateKey) -> Box<dyn Signer> {
         Box::new(HashSigner)
     }
@@ -48,6 +54,10 @@ impl Context for HashContext {
 pub struct HashSigner;
 
 impl Signer for HashSigner {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn sign(&self, message: &[u8]) -> Result<Signature, SigningError> {
         Ok(Signature::new(Sha512::digest(message).to_vec()))
     }
@@ -65,6 +75,10 @@ impl Signer for HashSigner {
 pub struct HashVerifier;
 
 impl Verifier for HashVerifier {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn verify(
         &self,
         message: &[u8],

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -31,6 +31,9 @@ pub use signature::Signature;
 
 /// A signer for arbitrary messages
 pub trait Signer: Send {
+    /// Return the algorithm name used for signing.
+    fn algorithm_name(&self) -> &str;
+
     /// Signs the given message
     fn sign(&self, message: &[u8]) -> Result<Signature, SigningError>;
 
@@ -50,6 +53,9 @@ impl Clone for Box<dyn Signer> {
 
 /// Verifies message signatures
 pub trait Verifier: Send {
+    /// Return the algorithm name used for verification.
+    fn algorithm_name(&self) -> &str;
+
     /// Verifies that the provided signature is valid for the given message and public key
     fn verify(
         &self,
@@ -61,6 +67,9 @@ pub trait Verifier: Send {
 
 /// A context for creating signers and verifiers
 pub trait Context {
+    /// Return the algorithm name provided by this context.
+    fn algorithm_name(&self) -> &str;
+
     /// Creates a new signer with the given private key
     fn new_signer(&self, key: PrivateKey) -> Box<dyn Signer>;
 

--- a/libcylinder/src/secp256k1/mod.rs
+++ b/libcylinder/src/secp256k1/mod.rs
@@ -31,6 +31,8 @@ use crate::{
     VerificationError, Verifier,
 };
 
+const ALGORITHM_NAME: &str = "secp256k1";
+
 pub struct Secp256k1Context {
     context: Arc<secp256k1::Secp256k1<secp256k1::All>>,
 }
@@ -50,6 +52,10 @@ impl Default for Secp256k1Context {
 }
 
 impl Context for Secp256k1Context {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn new_signer(&self, key: PrivateKey) -> Box<dyn Signer> {
         Box::new(Secp256k1Signer::new(self.context.clone(), key))
     }
@@ -91,6 +97,10 @@ impl Secp256k1Signer {
 }
 
 impl Signer for Secp256k1Signer {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn sign(&self, message: &[u8]) -> Result<Signature, SigningError> {
         let mut sha = Sha256::new();
         sha.input(message);
@@ -131,6 +141,10 @@ impl Secp256k1Verifier {
 }
 
 impl Verifier for Secp256k1Verifier {
+    fn algorithm_name(&self) -> &str {
+        ALGORITHM_NAME
+    }
+
     fn verify(
         &self,
         message: &[u8],


### PR DESCRIPTION
Add the algorithm name to the Context, Signer and Verifier traits.  This will allow the users of multiple implementations to annotate any output with the algorithm used to produce the output, or validate that the correct algorithm is being used to verify a signature.
