### PR TITLE
Export KeyLoadError from top-level

### DIFF
--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -28,7 +28,7 @@ mod key;
 pub mod secp256k1;
 mod signature;
 
-pub use error::{ContextError, SignatureParseError, SigningError, VerificationError};
+pub use error::{ContextError, KeyLoadError, SignatureParseError, SigningError, VerificationError};
 #[cfg(feature = "key-load")]
 pub use key::load::load_user_key;
 pub use key::{KeyParseError, PrivateKey, PublicKey};


### PR DESCRIPTION
This error is not visible to the library unless it's exported at the
top-level since the error module is private.

Signed-off-by: Logan Seeley <seeley@bitwise.io>