### PR TITLE
Modify key load API

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -46,19 +46,23 @@ hash = ["sha2"]
 jwt = ["json", "base64"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
-key-load = ["dirs", "whoami", "tempdir"]
+key-load = ["dirs", "log", "whoami", "tempdir"]
 
 [dependencies]
 base64 = { version = "0.13", optional = true }
 dirs = { version = "2.0", optional = true }
 json = { version = "0.12", optional = true }
+log = { version = "0.4", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.7"
 rust-crypto = "0.2"
 secp256k1 = "0.19"
 sha2 = { version = "0.9", optional = true }
-whoami = { version = "0.9.0", optional = true }
 tempdir = { version = "0.3", optional = true }
+whoami = { version = "0.9.0", optional = true }
+
+[dev-dependencies]
+serial_test = "0.5"
 
 [package.metadata.docs.rs]
 features = [

--- a/libcylinder/src/key/load.rs
+++ b/libcylinder/src/key/load.rs
@@ -17,110 +17,161 @@
 
 use std::env;
 use std::fs::File;
-use std::io::Read;
-use std::path::PathBuf;
+use std::io::{ErrorKind, Read};
+use std::path::{Path, PathBuf};
 
 use crate::error::KeyLoadError;
 use crate::PrivateKey;
 
-// determines the key name and path of the private key file
-pub fn load_user_key(
-    key_name: Option<&str>,
-    default_path: &str,
-) -> Result<PrivateKey, KeyLoadError> {
-    let name: String = match key_name {
-        Some(name) => String::from(name),
-        None => {
-            if let Ok(user) = env::var("USER") {
-                user
-            } else {
-                whoami::username()
-            }
+/// Returns a list of possible paths to search for the private key file.
+/// The value of the `CYLINDER_PATH` environment variable will returned if it exists
+/// and is valid unicode. If the value of the `CYLINDER_PATH` environment variable
+/// is not valid unicode or is not set, the default path will be returned.
+pub fn current_user_search_path() -> Vec<PathBuf> {
+    match env::var("CYLINDER_PATH") {
+        Ok(value) => value
+            .split(':')
+            .map(|s| Path::new(s).to_path_buf())
+            .collect(),
+        Err(env::VarError::NotUnicode(_)) => {
+            let mut dir = match dirs::home_dir() {
+                Some(dir) => dir,
+                None => Path::new(".").to_path_buf(),
+            };
+            dir.push(".cylinder");
+            dir.push("keys");
+            warn!(
+                "Value for CYLINDER_PATH is not unicode, unable to parse path, using default {:?}",
+                dir
+            );
+            vec![dir]
         }
-    };
-
-    // if the default path is an environment variable retrieve its value
-    let key_path = match env::var(&default_path) {
-        Ok(path) => path,
-        Err(_) => default_path.to_string(),
-    };
-
-    // check if the key name is a path
-    if name.contains('/') {
-        Ok(load_key_file(None, &name)?)
-    } else {
-        // if the key name is not a path check to see if it is an environment variable
-        let name = match env::var(&name) {
-            Ok(val) => val,
-            Err(_) => name,
-        };
-        // if key_path contains multiple paths check each path
-        if key_path.contains(':') {
-            let paths = key_path.split(':');
-            for path in paths {
-                match load_key_file(Some(name.clone()), &path) {
-                    Ok(key) => return Ok(key),
-                    Err(_) => continue,
-                }
-            }
-            Err(KeyLoadError(format!(
-                "Failed to find key file in {}",
-                &key_path
-            )))
-        } else {
-            Ok(load_key_file(Some(name), &key_path)?)
+        Err(env::VarError::NotPresent) => {
+            let mut dir = match dirs::home_dir() {
+                Some(dir) => dir,
+                None => Path::new(".").to_path_buf(),
+            };
+            dir.push(".cylinder");
+            dir.push("keys");
+            vec![dir]
         }
     }
 }
 
-// constructs the full path of the private key file
-fn load_key_file(key_name: Option<String>, key_path: &str) -> Result<PrivateKey, KeyLoadError> {
-    let mut path = PathBuf::from(key_path);
-    if let Some(key_name) = key_name {
-        path.push(key_name);
-    }
-    if path.exists() {
-        read_private_key(path)
-    } else {
-        path.set_extension("priv");
-        if path.exists() {
-            read_private_key(path)
-        } else {
-            Err(KeyLoadError(format!(
-                "Failed to load key: could not be found {}",
-                path.as_path().display()
-            )))
+/// Returns the name of the current private key file. The value of the
+/// `CYLINDER_KEY_NAME` environment variable will be returned if it exists and
+/// is valid unicode. If the value of the `CYLINDER_KEY_NAME` environment variable
+/// is not valid unicode or is not set, the default path will be returned.
+pub fn current_user_key_name() -> String {
+    match env::var("CYLINDER_KEY_NAME") {
+        Ok(value) => value,
+        Err(env::VarError::NotUnicode(_)) => {
+            let key_name = whoami::username();
+            warn!(
+                "Value for CYLINDER_KEY_NAME is not unicode, using default {:?}",
+                key_name
+            );
+            key_name
         }
+        Err(env::VarError::NotPresent) => whoami::username(),
     }
 }
 
-// Reads a private key from the given path
-fn read_private_key(path: PathBuf) -> Result<PrivateKey, KeyLoadError> {
-    let mut file = File::open(&path).map_err(|err| {
-        KeyLoadError(format!(
-            "Unable to open key file '{}': {}",
-            path.display(),
-            err,
-        ))
-    })?;
+/// Returns the private key from the given name and search path.
+///
+/// # Arguments
+///
+/// * `name` - The name of the private key file
+/// * `search_path` - The private key file path
+///
+/// Returns an error in any of the following cases:
+/// * The given file cannot be opened
+/// * The key cannot be loaded from the given file
+pub fn load_key(name: &str, search_path: &[PathBuf]) -> Result<Option<PrivateKey>, KeyLoadError> {
+    match search_path.iter().find_map(|path| {
+        let mut key_path = path.clone();
+        key_path.push(name);
+        key_path.set_extension("priv");
+
+        if key_path.exists() && key_path.is_file() {
+            match File::open(key_path) {
+                Ok(f) => Some(Ok(f)),
+                Err(e) => match e.kind() {
+                    ErrorKind::PermissionDenied => None,
+                    _ => Some(Err(e)),
+                },
+            }
+        } else {
+            None
+        }
+    }) {
+        Some(Ok(file)) => match load_key_from_file(file) {
+            Ok(key) => Ok(Some(key)),
+            Err(e) => Err(e),
+        },
+        Some(Err(err)) => Err(KeyLoadError::with_source(
+            Box::new(err),
+            "Unable to retrieve key",
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Returns the private key from the given path.
+///
+/// # Arguments
+///
+/// * `path` - The full path of the private key file
+///
+/// Returns an error in any of the following cases:
+/// * The given file cannot be opened
+/// * `load_key_from_file` cannot retrieve the key from the file
+pub fn load_key_from_path(path: &Path) -> Result<PrivateKey, KeyLoadError> {
+    match File::open(&path) {
+        Ok(f) => match load_key_from_file(f) {
+            Ok(key) => Ok(key),
+            Err(e) => Err(KeyLoadError::with_source(
+                Box::new(e),
+                &format!("Unable to load key from path: {:?}", path),
+            )),
+        },
+        Err(err) => Err(KeyLoadError::with_source(
+            Box::new(err),
+            &format!("Unable to open key file: {:?}", path),
+        )),
+    }
+}
+
+/// Returns the private key from the given file.
+///
+/// # Arguments
+///
+/// * `file` - The open key file
+///
+/// Returns an error in any of the following cases:
+/// * The given file cannot be read
+/// * The file is empty
+/// * The hex string read from the file cannot be converted into the private key
+fn load_key_from_file(file: File) -> Result<PrivateKey, KeyLoadError> {
+    let mut key_file = file;
 
     let mut buf = String::new();
-    file.read_to_string(&mut buf).map_err(|err| {
-        KeyLoadError(format!(
-            "Unable to read key file '{}': {}",
-            path.display(),
-            err,
-        ))
-    })?;
+    key_file
+        .read_to_string(&mut buf)
+        .map_err(|err| KeyLoadError::with_source(Box::new(err), "Unable to read key file"))?;
     let key = match buf.lines().next() {
         Some(k) => k.trim().to_string(),
         None => {
-            return Err(KeyLoadError(format!("Empty key file: {}", path.display())));
+            return Err(KeyLoadError::new(&format!(
+                "Empty key file: {:?}",
+                key_file
+            )));
         }
     };
 
-    Ok(PrivateKey::new_from_hex(&key)
-        .map_err(|err| KeyLoadError(format!("unable to create private key from hex: {}", err)))?)
+    Ok(PrivateKey::new_from_hex(&key).map_err(|err| {
+        KeyLoadError::with_source(Box::new(err), "unable to create private key from hex: {}")
+    })?)
 }
 
 #[cfg(test)]
@@ -128,28 +179,24 @@ mod tests {
     use super::*;
     use crate::PrivateKey;
 
+    use serial_test::serial;
     use std::fs::File;
     use std::io::Write;
     use tempdir::TempDir;
 
-    // tests that when an existing key name and default path are given load_user_key returns the
-    // private key
+    /// Tests that when `load_key` is called with a valid key name and path it successfully returns the
+    /// private key.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Call `load_key` with the private key file name and path
+    /// 3. Ensure the private key is returned.
     #[test]
-    fn retrieve_key_success() {
+    fn load_key_success() {
         let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
-        let default_path = temp_dir
-            .path()
-            .to_str()
-            .expect("Failed to get default path");
 
-        let key_path = temp_dir
-            .path()
-            .join(key_name)
-            .to_str()
-            .expect("Failed to get path")
-            .to_string();
+        let key_path = temp_dir.path().join(key_name);
 
         let mut temp_file =
             File::create(&key_path).expect("Unable to create temp private key file");
@@ -162,157 +209,346 @@ mod tests {
         writeln!(temp_file, "{}", private_key.as_hex())
             .expect("Unable to write private key to file");
 
-        let retrieved_private_key =
-            load_user_key(Some(key_name), default_path).expect("Unable retrieve key from file");
-
-        assert_eq!(retrieved_private_key.into_bytes(), private_key.into_bytes(),);
-    }
-
-    // tests that when no key name is given and the USER environment variable is set the value of
-    // the user environment variable will be used as the key_name and load_user_key returns the
-    // private key successfully
-    #[test]
-    fn retrieve_key_success_no_keyname() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
-
-        let key = "USER";
-        env::set_var(key, "test_user");
-        assert_eq!(env::var("USER"), Ok("test_user".to_string()));
-
-        let default_path = temp_dir
-            .path()
-            .to_str()
-            .expect("Failed to get default path");
-
-        let key_path = temp_dir
-            .path()
-            .join("test_user.priv")
-            .to_str()
-            .expect("Failed to get path")
-            .to_string();
-
-        let mut temp_file =
-            File::create(&key_path).expect("Unable to create temp private key file");
-
-        let private_key = PrivateKey::new(vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ]);
-
-        writeln!(temp_file, "{}", private_key.as_hex())
-            .expect("Unable to write private key to file");
-
-        let retrieved_private_key =
-            load_user_key(None, default_path).expect("Unable retrieve key from file");
-
-        assert_eq!(retrieved_private_key.into_bytes(), private_key.into_bytes(),);
-    }
-
-    // tests that when an environment variable is given as the default path load_user_key
-    // successfully returns the private key
-    #[test]
-    fn retrieve_key_success_environment_var() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
-
-        let key_name = "test_key.priv";
-        let default_path = temp_dir
-            .path()
-            .to_str()
-            .expect("Failed to get default path");
-
-        let key_path = temp_dir
-            .path()
-            .join(key_name)
-            .to_str()
-            .expect("Failed to get path")
-            .to_string();
-
-        let key = "TEST_KEY_PATH";
-        env::set_var(key, default_path);
-        assert_eq!(env::var("TEST_KEY_PATH"), Ok(default_path.to_string()));
-
-        let mut temp_file =
-            File::create(&key_path).expect("Unable to create temp private key file");
-
-        let private_key = PrivateKey::new(vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ]);
-
-        writeln!(temp_file, "{}", private_key.as_hex())
-            .expect("Unable to write private key to file");
-
-        let retrieved_private_key =
-            load_user_key(Some(key_name), "TEST_KEY_PATH").expect("Unable retrieve key from file");
-
-        assert_eq!(retrieved_private_key.into_bytes(), private_key.into_bytes(),);
-    }
-
-    // tests that when an environment variable is given as the default path and
-    // it contains multiple paths load_user_key uses the correct path and successfully
-    // returns the private key
-    #[test]
-    fn retrieve_key_success_environment_var2() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
-
-        let key_name = "test_key.priv";
-        let default_path = temp_dir
-            .path()
-            .to_str()
-            .expect("Failed to get default path");
-
-        let key_path = temp_dir
-            .path()
-            .join(key_name)
-            .to_str()
-            .expect("Failed to get path")
-            .to_string();
-
-        let paths = format!("test_key/keys:{}", default_path);
-        let key = "TEST_PATH_MULTIPLE";
-        env::set_var(key, paths.clone());
-        assert_eq!(
-            env::var("TEST_PATH_MULTIPLE"),
-            Ok(paths.clone().to_string())
-        );
-
-        let mut temp_file =
-            File::create(&key_path).expect("Unable to create temp private key file");
-
-        let private_key = PrivateKey::new(vec![
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0, 0, 1,
-        ]);
-
-        writeln!(temp_file, "{}", private_key.as_hex())
-            .expect("Unable to write private key to file");
-
-        let retrieved_private_key = load_user_key(Some(key_name), "TEST_PATH_MULTIPLE")
+        let retrieved_private_key = load_key("test_key", &[temp_dir.path().to_path_buf()])
             .expect("Unable retrieve key from file");
 
-        assert_eq!(retrieved_private_key.into_bytes(), private_key.into_bytes(),);
+        assert_eq!(
+            retrieved_private_key.unwrap().into_bytes(),
+            private_key.into_bytes(),
+        );
     }
 
-    // tests that if the given file with the given key name is empty load_user_key will fail
+    /// Tests that when the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables are set
+    /// with the key name a path, `key_load` will successfully retrieve the private key if passed
+    /// current_user_key_name() and current_user_search_path() as arguments.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Set the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables to the name and path
+    ///    of the key file.
+    /// 3. Ensure the environment variables were set correctly.
+    /// 4. Call `load_key` with current_user_key_name() and current_user_search_path() as arguments.
+    /// 5. Ensure the private key is returned.
     #[test]
-    fn retrieve_key_fail_empty_file() {
+    #[serial(env_var)]
+    fn load_key_env_var_success() {
         let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
-        let default_path = temp_dir
-            .path()
-            .to_str()
-            .expect("Failed to get default path");
 
-        let key_path = temp_dir
-            .path()
-            .join(key_name)
-            .to_str()
-            .expect("Failed to get path")
-            .to_string();
+        let key_path = temp_dir.path().join(key_name);
+
+        let path_value = temp_dir.path().to_str().expect("failed to make path value");
+
+        let env_key_name = "CYLINDER_KEY_NAME";
+        let env_key_path = "CYLINDER_PATH";
+        env::set_var(env_key_name, "test_key");
+        env::set_var(env_key_path, path_value);
+        assert_eq!(env::var("CYLINDER_KEY_NAME"), Ok("test_key".to_string()));
+        assert_eq!(env::var("CYLINDER_PATH"), Ok(path_value.to_string()));
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key = load_key(&current_user_key_name(), &current_user_search_path())
+            .expect("Unable retrieve key from file");
+
+        assert_eq!(
+            retrieved_private_key.unwrap().into_bytes(),
+            private_key.into_bytes()
+        );
+
+        env::remove_var("CYLINDER_KEY_NAME");
+        env::remove_var("CYLINDER_PATH");
+        assert!(env::var("CYLINDER_KEY_NAME").is_err());
+        assert!(env::var("CYLINDER_PATH").is_err());
+    }
+
+    /// Tests that when the CYLINDER_PATH environment variable is set with multiple paths,
+    /// `key_load` will successfully retrieve the private key if passed
+    /// current_user_key_name() and current_user_search_path() as arguments.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Set the CYLINDER_KEY_NAME env variable to the name of the private key file.
+    /// 3. Set the CYLINDER_PATH env variable to be two different file paths, the second
+    ///    being the correct path.
+    /// 3. Ensure the environment variables were set correctly.
+    /// 4. Call `load_key` with current_user_key_name() and current_user_search_path() as arguments.
+    /// 5. Ensure the private key is returned.
+    #[test]
+    #[serial(env_var)]
+    fn load_key_env_var_multiple_paths_success() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
+
+        let path_value = temp_dir.path().to_str().expect("failed to make path value");
+
+        let paths = format!("test_key/keys/:{}", path_value);
+
+        let env_key_name = "CYLINDER_KEY_NAME";
+        let env_key_path = "CYLINDER_PATH";
+        env::set_var(env_key_name, "test_key");
+        env::set_var(env_key_path, paths.clone());
+        assert_eq!(env::var("CYLINDER_KEY_NAME"), Ok("test_key".to_string()));
+        assert_eq!(env::var("CYLINDER_PATH"), Ok(paths.to_string()));
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key = load_key(&current_user_key_name(), &current_user_search_path())
+            .expect("Unable retrieve key from file");
+
+        assert_eq!(
+            retrieved_private_key.unwrap().into_bytes(),
+            private_key.into_bytes()
+        );
+
+        env::remove_var("CYLINDER_KEY_NAME");
+        env::remove_var("CYLINDER_PATH");
+        assert!(env::var("CYLINDER_KEY_NAME").is_err());
+        assert!(env::var("CYLINDER_PATH").is_err());
+    }
+
+    /// Tests that when the CYLINDER_PATH environment variable is set with nonexisistant paths, and
+    /// no key file exists in the default location `key_load` will return None when passed
+    /// current_user_key_name() and current_user_search_path() as arguments.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Set the CYLINDER_KEY_NAME env variable to the name of the private key file.
+    /// 3. Set the CYLINDER_PATH env variable to be two different incorrect file paths.
+    /// 3. Ensure the environment variables were set correctly.
+    /// 4. Call `load_key` with current_user_key_name() and current_user_search_path() as arguments.
+    /// 5. Ensure None is returned.
+    #[test]
+    #[serial(env_var)]
+    fn load_key_env_var_bad_paths_none() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
+
+        let paths = "test_key/keys/:bad_path/keys";
+
+        let env_key_name = "CYLINDER_KEY_NAME";
+        let env_key_path = "CYLINDER_PATH";
+        env::set_var(env_key_name, "test_key");
+        env::set_var(env_key_path, paths.clone());
+        assert_eq!(env::var("CYLINDER_KEY_NAME"), Ok("test_key".to_string()));
+        assert_eq!(env::var("CYLINDER_PATH"), Ok(paths.to_string()));
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key = load_key(&current_user_key_name(), &current_user_search_path())
+            .expect("Unable retrieve key from file");
+
+        assert!(retrieved_private_key.is_none());
+
+        env::remove_var("CYLINDER_KEY_NAME");
+        env::remove_var("CYLINDER_PATH");
+        assert!(env::var("CYLINDER_KEY_NAME").is_err());
+        assert!(env::var("CYLINDER_PATH").is_err());
+    }
+
+    /// Tests that when the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables are not set
+    /// and a private key file does not exist at the default location `key_load` will return None
+    /// when passed current_user_key_name() and current_user_search_path() as arguments.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Remove the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables.
+    /// 3. Ensure the environment variables don't exist.
+    /// 4. Call `load_key` with current_user_key_name() and current_user_search_path() as arguments.
+    /// 5. Ensure that None is returned.
+    #[test]
+    #[serial(env_var)]
+    fn load_key_none_success() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
+
+        env::remove_var("CYLINDER_KEY_NAME");
+        env::remove_var("CYLINDER_PATH");
+        assert!(env::var("CYLINDER_KEY_NAME").is_err());
+        assert!(env::var("CYLINDER_PATH").is_err());
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key = load_key(&current_user_key_name(), &current_user_search_path())
+            .expect("Unable retrieve key from file");
+
+        assert!(retrieved_private_key.is_none());
+    }
+
+    /// Tests that when the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables are not set
+    /// and a private key file exists at the default location, `key_load` will successfully
+    /// return the private key stored at the default location when passed current_user_key_name()
+    /// and current_user_search_path() as arguments.
+    ///
+    /// 1. Create a temporary directory and set it to be the home directory.
+    /// 2. Build the default private key file path `$HOME/.cylinder/keys/<username>.priv`.
+    /// 3. Unset the CYLINDER_KEY_NAME and CYLINDER_PATH environment variables.
+    /// 4. Ensure the environment variables are not set.
+    /// 5. Call `load_key` with current_user_key_name() and current_user_search_path() as arguments.
+    /// 6. Reset the home directory to its original value.
+    /// 7. Ensure the private key is returned.
+    #[test]
+    #[serial(env_var)]
+    fn load_key_default_path_success() {
+        let original_home = std::env::var("HOME").expect("failed to get original home dir");
+
+        let temp_home = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        std::env::set_var("HOME", temp_home.path());
+
+        let mut temp_path = temp_home.path().to_path_buf();
+
+        temp_path.push(".cylinder");
+        temp_path.push("keys");
+
+        std::fs::create_dir_all(temp_path.clone()).expect("Unable to create key directory");
+
+        let key_file = format!("{}.priv", whoami::username());
+
+        env::remove_var("CYLINDER_KEY_NAME");
+        env::remove_var("CYLINDER_PATH");
+        assert!(env::var("CYLINDER_KEY_NAME").is_err());
+        assert!(env::var("CYLINDER_PATH").is_err());
+
+        env::set_current_dir(&temp_path).unwrap();
+
+        let mut temp_file = File::create(key_file).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key = load_key(&current_user_key_name(), &current_user_search_path())
+            .expect("Unable retrieve key from file");
+
+        std::env::set_var("HOME", original_home);
+
+        assert_eq!(
+            retrieved_private_key.unwrap().into_bytes(),
+            private_key.into_bytes()
+        );
+    }
+
+    /// Tests that `load_key_from_path` returns a private key when given the full path to the
+    /// private key file.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Call `load_key_from_path` with the private key file path
+    /// 3. Ensure the private key is returned.
+    #[test]
+    fn load_key_from_path_success() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        let retrieved_private_key =
+            load_key_from_path(&key_path).expect("Unable retrieve key from file");
+
+        assert_eq!(retrieved_private_key.into_bytes(), private_key.into_bytes());
+    }
+
+    /// Tests that if the given key file is empty, load_key_from_path will fail.
+    ///
+    /// 1. Create an empty file in a temporary directory.
+    /// 2. Call `load_key_from_path` with the file path
+    /// 3. Ensure an error is returned.
+    #[test]
+    fn load_key_from_path_fail_empty_file() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
 
         File::create(&key_path).expect("Unable to create temp private key file");
 
-        assert!(load_user_key(Some(key_name), default_path).is_err());
+        assert!(load_key_from_path(&key_path).is_err());
+    }
+
+    /// Tests that if a bad file path is given, load_key_from_path will fail.
+    ///
+    /// 1. Create a private key file in a temporary directory and write a key to the file.
+    /// 2. Call `load_key_from_path` with a bad file path
+    /// 3. Ensure an error is returned.
+    #[test]
+    fn load_key_from_path_fail_bad_path() {
+        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+
+        let key_name = "test_key.priv";
+
+        let key_path = temp_dir.path().join(key_name);
+
+        let bad_path = Path::new("bad_path/keys/bad_file.priv");
+
+        let mut temp_file =
+            File::create(&key_path).expect("Unable to create temp private key file");
+
+        let private_key = PrivateKey::new(vec![
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ]);
+
+        writeln!(temp_file, "{}", private_key.as_hex())
+            .expect("Unable to write private key to file");
+
+        assert!(load_key_from_path(&bad_path).is_err());
     }
 }

--- a/libcylinder/src/key/load.rs
+++ b/libcylinder/src/key/load.rs
@@ -15,6 +15,54 @@
  * ------------------------------------------------------------------------------
  */
 
+//! Provides an API to retrieve private keys.
+//!
+//! Some tests in this module are run serially using the `serial_test` crate with the
+//! `#[serial(env_var)]` annotation added to the individual tests. This is required because
+//! multiple tests alter the same environment variables and may conflict with each other if
+//! run in parallel.
+//!
+//! Cylinder key load is guarded by the feature "key-load".
+//!
+//! # Example
+//!
+//! ## Retrieving a private key from a given path
+//!
+//! ```
+//! use std::path::Path;
+//! use cylinder::{load_key, load_key_from_path};
+//!
+//! let private_key_path = Path::new("/etc/splinter/keys/private_key.priv");
+//! let private_key = load_key_from_path(&private_key_path);
+//! ```
+//!
+//! ## Load private key from `current_user_search_path()` and `current_user_key_name()`
+//!
+//! ```
+//! use std::path::Path;
+//! use cylinder::{load_key, load_key_from_path, current_user_key_name, current_user_search_path};
+//!
+//! let search_path = current_user_search_path();
+//! let key_name = current_user_key_name();
+//!
+//! let private_key = cylinder::load_key(&key_name, &search_path);
+//! ```
+//!
+//! ## Load private key from a given path and name
+//!
+//! ```
+//! use std::path::{Path, PathBuf};
+//! use cylinder::{load_key, load_key_from_path};
+//!
+//! let mut path = PathBuf::new();
+//! path.push("/etc/splinter/keys");
+//!
+//! let search_path = vec![path];
+//! let key_name = "splinterd";
+//!
+//! let private_key = cylinder::load_key(key_name, &search_path);
+//!  ```
+
 use std::env;
 use std::fs::File;
 use std::io::{ErrorKind, Read};

--- a/libcylinder/src/lib.rs
+++ b/libcylinder/src/lib.rs
@@ -16,6 +16,10 @@
  * ------------------------------------------------------------------------------
  */
 
+#[cfg(feature = "key-load")]
+#[macro_use]
+extern crate log;
+
 mod error;
 #[cfg(feature = "hash")]
 #[cfg_attr(docsrs, doc(cfg(feature = "hash")))]
@@ -28,9 +32,17 @@ mod key;
 pub mod secp256k1;
 mod signature;
 
-pub use error::{ContextError, KeyLoadError, SignatureParseError, SigningError, VerificationError};
 #[cfg(feature = "key-load")]
-pub use key::load::load_user_key;
+pub use error::KeyLoadError;
+pub use error::{ContextError, SignatureParseError, SigningError, VerificationError};
+#[cfg(feature = "key-load")]
+pub use key::load::current_user_key_name;
+#[cfg(feature = "key-load")]
+pub use key::load::current_user_search_path;
+#[cfg(feature = "key-load")]
+pub use key::load::load_key;
+#[cfg(feature = "key-load")]
+pub use key::load::load_key_from_path;
 pub use key::{KeyParseError, PrivateKey, PublicKey};
 pub use signature::Signature;
 


### PR DESCRIPTION
Update the cylinder key load API to have 2 main methods for retrieving
private keys, a method for reading a private key from a file, a method
for retrieving the current private key file path and a method for
retrieving the current private key file name. Documentation and examples
have been added to to the module as well as updated tests.