### PR TITLE
Update dirs dependency to version 4

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -50,7 +50,7 @@ key-load = ["dirs", "log", "whoami", "tempdir"]
 
 [dependencies]
 base64 = { version = "0.13", optional = true }
-dirs = { version = "3.0", optional = true }
+dirs = { version = "4", optional = true }
 json = { version = "0.12", optional = true }
 log = { version = "0.4", optional = true }
 openssl = { version = "0.10", optional = true }


### PR DESCRIPTION
This change is made to track the latest dependency and is not intended
to have a functional impact.
