### PR TITLE
Update the list of project maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @chenette @cianx @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rberg2 @rbuysse @vaporos
+*       @agunde406 @isabeltomb @jsmitchell @peterschwarz @rbuysse @shannynalayna @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,25 +1,20 @@
 ## Maintainers
 
 ### Active Maintainers
-| Name | GitHub | RocketChat |
-| --- | --- | --- |
-| Andi Gunderson | agunde406 | agunde |
-| Anne Chenette | chenette | achenette |
-| Cian Montgomery | cianx | cianx |
-| Dan Middleton | dcmiddle | Dan |
-| Darian Plumb | dplumb94 | dplumb |
-| James Mitchell | jsmitchell | jsmitchell |
-| Peter Schwarz | peterschwarz | pschwarz |
-| Richard Berg | rberg2 | rberg2 |
-| Ryan Beck-Buysse | rbuysse | rbuysse |
-| Shawn Amundson | vaporos | amundson |
 
+| Name | GitHub |
+| --- | --- |
+| Andi Gunderson | agunde406 |
+| Isabel Tomb | isabeltomb |
+| James Mitchell | jsmitchell |
+| Peter Schwarz | peterschwarz |
+| Ryan Beck-Buysse | rbuysse |
+| Shannyn Telander | shannynalayna |
+| Shawn Amundson | vaporos |
 
 ### Retired Maintainers
-| Name | GitHub | RocketChat |
-| --- | --- | --- |
-| Adam Ludvik | aludvik | adamludvik |
-| Boyd Johnson | boydjohnson | boydjohnson |
-| Jamie Jason | jjason | jjason |
-| Nick Drozd | nick-drozd | drozd |
-| Zac Delventhal | delventhalz | zac |
+
+| Name | GitHub |
+| --- | --- |
+| Darian Plumb | dplumb94 |
+| Logan Seeley | ltseeley |


### PR DESCRIPTION
Updates both MAINTAINERS.md and CODEOWNERS with the current list of
project maintainers. Also updates the retired maintainers section; not
all maintainers previously listed in the file remain because some were
listed because the file was initialized with the list of Sawtooth
maintainers which wasn't entirely accurate.
