### PR TITLE
Add cyl CLI with "jwt generate" subcommand

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright 2021 Cargill Incorporated
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,16 +13,36 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# Exclude IDE and Editor files
-/.idea/
-*.sublime*
+[package]
+name = "cyl"
+version = "0.1.0"
+authors = ["Cargill Incorporated"]
+edition = "2018"
 
-/build/
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-cli/target
-cli/Cargo.lock
-libcylinder/target
-libcylinder/Cargo.lock
+[dependencies]
+cylinder = { path = "../libcylinder", features = ["jwt", "key-load"] }
+clap = "2"
+dirs = "4"
+log = "0.4"
+flexi_logger = "0.19"
 
-*.batch
-.coverage
+[features]
+default = []
+
+stable = [
+    "default",
+]
+
+experimental = [
+  # The experimental feature extends stable:
+  "stable",
+  # The following features are experimental:
+]
+
+[package.metadata.docs.rs]
+features = [
+  "stable",
+  "experimental"
+]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,0 +1,189 @@
+// Copyright 2018-2020 Cargill Incorporated
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Module containing CliError implementation.
+
+use std::error;
+use std::fmt;
+
+struct Source {
+    prefix: Option<String>,
+    source: Box<dyn error::Error>,
+}
+
+/// An error which is returned for reasons internal to the function.
+///
+/// This error is produced when a failure occurred within the function but the failure is due to an
+/// internal implementation detail of the function. This generally means that there is no specific
+/// information which can be returned that would help the caller of the function recover or
+/// otherwise take action.
+pub struct CliError {
+    message: Option<String>,
+    source: Option<Source>,
+}
+
+impl CliError {
+    /// Constructs a new `CliError` from a specified source error.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will simply pass through the
+    /// display of the source message unmodified.
+    pub fn from_source(source: Box<dyn error::Error>) -> Self {
+        Self {
+            message: None,
+            source: Some(Source {
+                prefix: None,
+                source,
+            }),
+        }
+    }
+
+    /// Constructs a new `CliError` from a specified source error and message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    pub fn from_source_with_message(source: Box<dyn error::Error>, message: String) -> Self {
+        Self {
+            message: Some(message),
+            source: Some(Source {
+                prefix: None,
+                source,
+            }),
+        }
+    }
+
+    /// Constructs a new `CliError` with a specified message string.
+    ///
+    /// The implementation of `std::fmt::Display` for this error will be the message string
+    /// provided.
+    pub fn with_message(message: String) -> Self {
+        Self {
+            message: Some(message),
+            source: None,
+        }
+    }
+}
+
+impl error::Error for CliError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match &self.source {
+            Some(s) => Some(s.source.as_ref()),
+            None => None,
+        }
+    }
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match &self.message {
+            Some(m) => write!(f, "{}", m),
+            None => match &self.source {
+                Some(s) => match &s.prefix {
+                    Some(p) => write!(f, "{}: {}", p, s.source),
+                    None => write!(f, "{}", s.source),
+                },
+                None => write!(f, "{}", std::any::type_name::<CliError>()),
+            },
+        }
+    }
+}
+
+impl fmt::Debug for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("CliError");
+
+        if let Some(message) = &self.message {
+            debug_struct.field("message", message);
+        }
+
+        if let Some(source) = &self.source {
+            if let Some(prefix) = &source.prefix {
+                debug_struct.field("prefix", prefix);
+            }
+
+            debug_struct.field("source", &source.source);
+        }
+
+        debug_struct.finish()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    /// Tests that errors constructed with `CliError::from_source` return a debug string of
+    /// the form `format!("CliError { {:?} }", source)`.
+    #[test]
+    fn test_debug_from_source() {
+        let msg = "test message";
+        let debug = "CliError { source: CliError { message: \"test message\" } }";
+        let err = CliError::from_source(Box::new(CliError::with_message(msg.to_string())));
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that errors constructed with `CliError::from_source_with_message` return a debug
+    /// string of the form `format!("CliError { message: {:?}, source: {:?} }", message,
+    /// source)`.
+    #[test]
+    fn test_debug_from_source_with_message() {
+        let msg = "test message";
+        let debug =
+            "CliError { message: \"test message\", source: CliError { message: \"unused\" } }";
+        let err = CliError::from_source_with_message(
+            Box::new(CliError::with_message("unused".to_string())),
+            msg.to_string(),
+        );
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that errors constructed with `CliError::with_message` return a debug
+    /// string of the form `format!("CliError { message: {:?} }", message)`.
+    #[test]
+    fn test_debug_with_message() {
+        let msg = "test message";
+        let debug = "CliError { message: \"test message\" }";
+        let err = CliError::with_message(msg.to_string());
+        assert_eq!(format!("{:?}", err), debug);
+    }
+
+    /// Tests that error constructed with `CliError::from_source` return a display
+    /// string which is the same as the source's display string.
+    #[test]
+    fn test_display_from_source() {
+        let msg = "test message";
+        let err = CliError::from_source(Box::new(CliError::with_message(msg.to_string())));
+        assert_eq!(format!("{}", err), msg);
+    }
+
+    /// Tests that error constructed with `CliError::from_source_with_message` return
+    /// message as the display string.
+    #[test]
+    fn test_display_from_source_with_message() {
+        let msg = "test message";
+        let err = CliError::from_source_with_message(
+            Box::new(CliError::with_message("unused".to_string())),
+            msg.to_string(),
+        );
+        assert_eq!(format!("{}", err), msg);
+    }
+
+    /// Tests that error constructed with `CliError::with_message` return message as the
+    /// display string.
+    #[test]
+    fn test_display_with_message() {
+        let msg = "test message";
+        let err = CliError::with_message(msg.to_string());
+        assert_eq!(format!("{}", err), msg);
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate log;
+
+mod error;
+
+use std::env;
+use std::path::Path;
+
+use cylinder::jwt::JsonWebTokenBuilder;
+use cylinder::secp256k1::Secp256k1Context;
+use cylinder::{
+    current_user_key_name, current_user_search_path, load_key, load_key_from_path, Context,
+    PrivateKey,
+};
+use flexi_logger::{LogSpecBuilder, Logger};
+
+use error::CliError;
+
+const APP_NAME: &str = env!("CARGO_PKG_NAME");
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn main() {
+    let matches = clap_app!(myapp =>
+        (name: APP_NAME)
+        (version: VERSION)
+        (author: "Cargill")
+        (about: "Cylinder CLI")
+        (@arg verbose: -v +multiple +global "Log verbosely")
+        (@arg quiet: -q --quiet +global "Do not display output")
+        (@setting SubcommandRequiredElseHelp)
+
+        (@subcommand jwt =>
+            (about: "Subcommands for generating and examining Cylinder JSON web tokens")
+            (@setting SubcommandRequiredElseHelp)
+            (@subcommand generate =>
+            (about: "Generates a JWT for a given private key")
+             (@arg private_key_file: -k --key +takes_value
+                        "Name or path of private key")
+            )
+        )
+
+    )
+    .get_matches();
+
+    // set default to info
+    let log_level = if matches.is_present("quiet") {
+        log::LevelFilter::Error
+    } else {
+        match matches.occurrences_of("verbose") {
+            0 => log::LevelFilter::Info,
+            1 => log::LevelFilter::Debug,
+            _ => log::LevelFilter::Trace,
+        }
+    };
+
+    let log_spec = LogSpecBuilder::new().default(log_level).build();
+
+    match Logger::with(log_spec)
+        .format(log_format)
+        .log_to_stdout()
+        .start()
+    {
+        Ok(_) => {}
+        #[cfg(test)]
+        // `FlexiLoggerError::Log` means the logger has already been initialized; this will happen
+        // when `run` is called more than once in the tests.
+        Err(flexi_logger::FlexiLoggerError::Log(_)) => {}
+        Err(err) => panic!("Failed to start logger: {}", err),
+    }
+
+    let res = match matches.subcommand() {
+        ("jwt", Some(matches)) => handle_jwt_subcommands(matches),
+        // Clap will have caught any unrecognized subcommands
+        (_, _) => unreachable!(),
+    };
+
+    if let Err(err) = res {
+        error!("{}", err);
+    }
+}
+
+fn handle_jwt_subcommands(matches: &clap::ArgMatches) -> Result<(), CliError> {
+    match matches.subcommand() {
+        ("generate", Some(matches)) => handle_jwt_generate(matches),
+        // Clap will have caught any unrecognized subcommands
+        (_, _) => unreachable!(),
+    }
+}
+
+fn handle_jwt_generate(matches: &clap::ArgMatches) -> Result<(), CliError> {
+    let key_name = matches.value_of("private_key_file");
+
+    let private_key = load_private_key(key_name)?;
+
+    let context = Secp256k1Context::new();
+    let signer = context.new_signer(private_key);
+
+    let encoded_token = JsonWebTokenBuilder::new().build(&*signer).map_err(|err| {
+        CliError::from_source_with_message(Box::new(err), "failed to build json web token".into())
+    })?;
+
+    info!("{}", encoded_token);
+
+    Ok(())
+}
+
+fn load_private_key(key_name: Option<&str>) -> Result<PrivateKey, CliError> {
+    if let Some(key_name) = key_name {
+        if key_name.contains('/') {
+            return load_key_from_path(Path::new(key_name))
+                .map_err(|err| CliError::from_source(Box::new(err)));
+        }
+    }
+
+    load_key(
+        &key_name
+            .map(String::from)
+            .unwrap_or_else(current_user_key_name),
+        &current_user_search_path(),
+    )
+    .map_err(|err| CliError::from_source(Box::new(err)))?
+    .ok_or_else(|| {
+        CliError::with_message({
+            format!(
+                "No signing key found in {}. Specify a valid key with the --key argument",
+                current_user_search_path()
+                    .iter()
+                    .map(|path| path.as_path().display().to_string())
+                    .collect::<Vec<String>>()
+                    .join(":")
+            )
+        })
+    })
+}
+
+pub fn log_format(
+    w: &mut dyn std::io::Write,
+    _now: &mut flexi_logger::DeferredNow,
+    record: &log::Record,
+) -> Result<(), std::io::Error> {
+    write!(w, "{}", record.args(),)
+}

--- a/justfile
+++ b/justfile
@@ -15,6 +15,7 @@
 
 crates := '\
     libcylinder \
+    cli
     '
 
 features := '\


### PR DESCRIPTION
This change introduces a `cyl` CLI tool with an initial "jwt generate" subcommand.  This command uses a key from the usual places and generates a basic cylinder JWT.  

This JWT can be used in conjunction with commands, such as using curl against a REST API with a Cylinder JWT authorization token.