### PR TITLE
Replace rust-crypto library with sha2 

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -42,7 +42,7 @@ experimental = [
   "hash",
 ]
 
-hash = ["sha2"]
+hash = []
 jwt = ["json", "base64"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
@@ -55,9 +55,8 @@ json = { version = "0.12", optional = true }
 log = { version = "0.4", optional = true }
 openssl = { version = "0.10", optional = true }
 rand = "0.8"
-rust-crypto = "0.2"
 secp256k1 = "0.20"
-sha2 = { version = "0.9", optional = true }
+sha2 = "0.10"
 tempdir = { version = "0.3", optional = true }
 whoami = { version = "1.1", optional = true }
 


### PR DESCRIPTION
Replace rust-crypto library with sha2:0.10, as rust-crypto is no longer
maintained. See advisory: https://rustsec.org/advisories/RUSTSEC-2016-0005

Signed-off-by: Lee Bradley <bradley@bitwise.io>