### PR TITLE
Replace tempdir library with tempfile 

### DIFF
--- a/libcylinder/Cargo.toml
+++ b/libcylinder/Cargo.toml
@@ -46,7 +46,7 @@ hash = []
 jwt = ["json", "base64"]
 # Add support for loading PEM encoded private keys
 pem = ["openssl"]
-key-load = ["dirs", "log", "whoami", "tempdir"]
+key-load = ["dirs", "log", "whoami"]
 
 [dependencies]
 base64 = { version = "0.13", optional = true }
@@ -57,11 +57,11 @@ openssl = { version = "0.10", optional = true }
 rand = "0.8"
 secp256k1 = "0.20"
 sha2 = "0.10"
-tempdir = { version = "0.3", optional = true }
 whoami = { version = "1.1", optional = true }
 
 [dev-dependencies]
 serial_test = "0.5"
+tempfile = "3"
 
 [package.metadata.docs.rs]
 features = [

--- a/libcylinder/src/key/load.rs
+++ b/libcylinder/src/key/load.rs
@@ -236,7 +236,7 @@ mod tests {
     use serial_test::serial;
     use std::fs::File;
     use std::io::Write;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     /// Tests that when `load_key` is called with a valid key name and path it successfully returns
     /// the private key.
@@ -246,7 +246,10 @@ mod tests {
     /// 3. Ensure the private key is returned.
     #[test]
     fn load_key_success() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -285,7 +288,10 @@ mod tests {
     #[test]
     #[serial(env_var)]
     fn load_key_env_var_success() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -339,7 +345,10 @@ mod tests {
     #[test]
     #[serial(env_var)]
     fn load_key_env_var_multiple_paths_success() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -394,7 +403,10 @@ mod tests {
     #[test]
     #[serial(env_var)]
     fn load_key_env_var_bad_paths_none() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -448,7 +460,10 @@ mod tests {
     fn load_key_default_path_success() {
         let original_home = std::env::var("HOME").expect("failed to get original home dir");
 
-        let temp_home = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_home = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
         std::env::set_var("HOME", temp_home.path());
 
         let mut temp_path = temp_home.path().to_path_buf();
@@ -496,7 +511,10 @@ mod tests {
     /// 3. Ensure the private key is returned.
     #[test]
     fn load_key_from_path_success() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -526,7 +544,10 @@ mod tests {
     /// 3. Ensure an error is returned.
     #[test]
     fn load_key_from_path_fail_empty_file() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 
@@ -544,7 +565,10 @@ mod tests {
     /// 3. Ensure an error is returned.
     #[test]
     fn load_key_from_path_fail_bad_path() {
-        let temp_dir = TempDir::new("test_key_dir").expect("Failed to create temp dir");
+        let temp_dir = Builder::new()
+            .prefix("test_key_dir")
+            .tempdir()
+            .expect("Failed to create temp dir");
 
         let key_name = "test_key.priv";
 


### PR DESCRIPTION
Replace tempdir library with tempfile:3 because tempdir is no longer
maintained. See advisory: https://rustsec.org/advisories/RUSTSEC-2018-0017

Also move the library to be a dev dependency, as it is only ever used for unit
testing purposes.

Signed-off-by: Amelia Bradley <bradley@bitwise.io>